### PR TITLE
Adding better error handling

### DIFF
--- a/callable.sh
+++ b/callable.sh
@@ -45,9 +45,12 @@ Github__callable_labels(){
         local label=$(echo $line | awk -F':' '{print $1}')
         local color=$(echo $line | awk -F':' '{print $2}')
 
-        success=$(Github__create_single_label "$repo" "$label" "$color")
-        if [[ "$success" -eq "1" ]]; then
+        response=$(Github__create_single_label "$repo" "$label" "$color")
+
+        if [[ "$response" = "added" ]]; then
             Logger__success "Added label: $label"
+        elif [[ "$response" = "updated" ]]; then
+            Logger__success "Updated label: $label"
         else
             Logger__warning "Failed to add label: $label"
         fi

--- a/lib/labels.sh
+++ b/lib/labels.sh
@@ -6,34 +6,36 @@
 # @param $1: Repository name
 # @param $2: Label name
 # @param $3: Label color
+#
+# @returns: 'failure' if we failed to add / update the label
+#           'added' if we successfully added the label
+#           'updated' if we successfully updated the label
 ##################################################
 Github__create_single_label(){
     # Try to create via POST
-    local post_output=$(curl \
-        -s \
+    local post_response=$(curl \
+        -s -o /dev/null -w "%{http_code}" \
         -H "Authorization: token $GITHUB_TOKEN" \
         -X POST "https://api.github.com/repos/$1/labels" \
         -d "{\"name\":\"$2\", \"color\":\"$3\"}")
 
     # Checking if POST worked
-    local post_errors=$(echo "$post_output" | grep "\"errors\":")
-    if [[ -z "$post_errors" ]]; then
-        echo "1"
+    if [[ $post_response =~ 2.. ]]; then
+        echo "added"
         return
     fi
 
     # Update via PATCH
-    local patch_output=$(curl \
-        -s \
+    local patch_response=$(curl \
+        -s -o /dev/null -w "%{http_code}" \
         -H "Authorization: token $GITHUB_TOKEN" \
         -X PATCH "https://api.github.com/repos/$1/labels/$2" \
         -d "{\"name\":\"$2\", \"color\":\"$3\"}")
 
     # Checking if PATCH worked
-    local patch_errors=$(echo "$patch_output" | grep "\"errors\":")
-    if [[ -z "$patch_errors" ]]; then
-        echo "1"
+    if [[ $patch_response =~ 2.. ]]; then
+        echo "updated"
     else
-        echo "0"
+        echo "failure"
     fi
 }


### PR DESCRIPTION
Fixes #9

Now I'm reading the HTTP response as opposed to trying to parse the response.  Much more reliable.  Will succeed on all `2xx` responses.

Also am distinguishing between added + updated:

```
<< Github >>: Added label: duplicate
<< Github >>: Updated label: feature
```

@kylemac basically what's in the `$post_response` + `$patch_response` is simply the HTTP response code.  Other than that I think you can follow the logic!
