### PR TITLE
Adding a fool proof init flow

### DIFF
--- a/callable.sh
+++ b/callable.sh
@@ -24,6 +24,13 @@ Github__callable_help(){
 # @param $1: The label config file
 ##################################################
 Github__callable_labels(){
+    # Checking if variable exists
+    Github_validate_token
+    if [[ $? -ne 0 ]]; then
+        Logger__error "GITHUB_TOKEN must be set in the .ashrc file before calling labels"
+        return
+    fi
+
     # Checking if we've got a valid config file
     local label_config_file="$Github_label_config_directory/$1"
     if [[ ! -f "$label_config_file" ]]; then

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+##################################################
+# Validates if the GITHUB_TOKEN is set in the
+# .ashrc file.  Prompts the user to set one if it
+# hasn't been set yet.
+#
+# @returns: 0 if there is a Github token set at
+#               the end of this function call
+#           1 if there is *not* a Github token set
+#               at the end of this function call
+##################################################
+Github_validate_token(){
+    # Checking if variable exists
+    if [[ -z "$GITHUB_TOKEN" ]]; then
+        local response
+        Logger__alert "GITHUB_TOKEN is not set in the .ashrc file"
+        Logger__prompt "Would you like to set one now? (y/n): "; read response
+
+        # If user wants to input their token
+        if [[ "$response" = "y" || "$response" = "Y" ]]; then
+            local github_token
+            Logger__prompt "Enter Github Token (https://github.com/settings/tokens): "; read github_token
+
+            local export_line="export GITHUB_TOKEN=\"$github_token\""
+            echo "$export_line" >> $Ash_rc_file # Store it to .ashrc
+            export GITHUB_TOKEN="$github_token" # Exporting for current use
+            return 0
+        else
+            return 1
+        fi
+    else
+        return 0
+    fi
+}


### PR DESCRIPTION
If the user doesn't have their GITHUB_TOKEN set yet, we prompt if they
would like to add it.  If they don't add it we halt the operation.  If
they do add it, we continue as normal.

Fixes #1 
