### PR TITLE
Discussion to update web defaults

### DIFF
--- a/extras/label_configs/carrots
+++ b/extras/label_configs/carrots
@@ -12,8 +12,6 @@ feature:75989b
 
 # Status
 blocked:000000
-in-progress:f4f7eb
-needs-review:d9e2b8
 on-hold:939b75
 
 # Priorities


### PR DESCRIPTION
This has been the default I've been using for a while as on many projects.We haven't utilized and/or have a better flow due to `zenhub`.
```
feature-request:adc6c8
in-progress:f4f7eb
needs-review:d9e2b8
on-hold:939b75
```

`feature-request`, is a feature that can be open/closed based on discussion in the thread. I've never seen this used. `in-progress`, is a label that we have a zenhub pipeline for. `needs-review`, we have the `Reviewers` option on pull requests as well as a pipeline for QA. `on-hold`, typically ends up being `blocked`. 

I'm no longer importing the `carrots` base file as I don't want to interrupt other workflows in `ios`/`android` that may be utilizing these labels.